### PR TITLE
Renamed Distrito Federal

### DIFF
--- a/Channels/Forecast_Channel/forecastlists.py
+++ b/Channels/Forecast_Channel/forecastlists.py
@@ -445,7 +445,7 @@ weathercities035["Fort-de-France"] = ["Fort-de-France", "Fort-de-France", "Marti
 
 weathercities036 = collections.OrderedDict()
 
-weathercities036["Mexico City"] = ["Mexico City", "Distrito Federal", "Mexico", "0dd1b98109030000"]
+weathercities036["Mexico City"] = ["Mexico City", "Mexico City", "Mexico", "0dd1b98109030000"]
 weathercities036["Aguascalientes"] = ["Aguascalientes", "Aguascalientes", "Mexico", "0f8fb74103030000"]
 weathercities036["Mexicali"] = ["Mexicali", "Baja California", "Mexico", "1738ade401030000"]
 weathercities036["Tijuana"] = ["Tijuana", "Baja California", "Mexico", "1722acca00030000"]


### PR DESCRIPTION

Author Name for Credits: Arturo Andrade
Short Description: Distrito Federal Rename
Long Description: Since Distrito Federal in Mexico have been renamed this should be updated.

Mexico City doesn't has a state, its the Capital of the Country.
