### PR TITLE
Fixed Nikaia region

### DIFF
--- a/Channels/Forecast_Channel/forecastlists.py
+++ b/Channels/Forecast_Channel/forecastlists.py
@@ -30107,13 +30107,13 @@ weathercities079["Karditsa"] = [
 weathercities079["Nikaia"] = [
     ["Nikea", "Nikaia", "Nikea", "Nikea", "Nikea", "Nikea", "Nikea"],
     [
-        "テッサリーア",
-        "Thessaly",
-        "Thessalien",
-        "Thessalie",
-        "Tesalia",
-        "Tessaglia",
-        "Thessalië",
+        "アッティカ",
+        "Attica",
+        "Attika",
+        "Attique",
+        "Ática",
+        "Attica",
+        "Attika"
     ],
     ["ギリシャ", "Greece", "Griechenland", "Grèce", "Grecia", "Grecia", "Griekenland"],
     "1af710ca00030000",


### PR DESCRIPTION

Author Name for Credits: Eridion

Short Description: Fixed Nikaia region on Forecast channel

Long Description: DESCRIPTION I found an interesting bug on forecast channel with on select the region says that Nikaia is in Thessaly but this Nikaia referred on forecast list refers to Attica one i can confirm it with Forecast channel globe and this PR fixes it


https://user-images.githubusercontent.com/38893086/217022029-966aa026-267b-4b4d-b98c-5c4cba3f9230.mp4

